### PR TITLE
Added null checks to throw exceptions instead of segfauting the JVM.

### DIFF
--- a/src/main/java/com/mapzen/jpostal/AddressExpander.java
+++ b/src/main/java/com/mapzen/jpostal/AddressExpander.java
@@ -21,13 +21,17 @@ public class AddressExpander {
     static native synchronized void teardown();
 
     public String[] expandAddress(String address) {
-        ExpanderOptions options = new ExpanderOptions.Builder().build();
-        synchronized(this) {
-            return libpostalExpand(address, options);
-        }
+        return expandAddressWithOptions(address, new ExpanderOptions.Builder().build());
     }
 
     public String[] expandAddressWithOptions(String address, ExpanderOptions options) {
+        if (address == null) {
+            throw new NullPointerException("String address must not be null");
+        }
+        if (options == null) {
+            throw new NullPointerException("ExpanderOptions options must not be null");
+        }
+
         synchronized(this) {
             return libpostalExpand(address, options);
         }

--- a/src/main/java/com/mapzen/jpostal/AddressParser.java
+++ b/src/main/java/com/mapzen/jpostal/AddressParser.java
@@ -21,13 +21,17 @@ public class AddressParser {
     }
 
     public ParsedComponent[] parseAddress(String address) {
-        ParserOptions options = new ParserOptions.Builder().build();
-        synchronized(this) {
-            return libpostalParse(address, options);
-        }
+        return parseAddressWithOptions(address, new ParserOptions.Builder().build());
     }
 
     public ParsedComponent[] parseAddressWithOptions(String address, ParserOptions options) {
+        if (address == null) {
+            throw new NullPointerException("String address must not be null");
+        }
+        if (options == null) {
+            throw new NullPointerException("ParserOptions options must not be null");
+        }
+
         synchronized(this) {
             return libpostalParse(address, options);
         }

--- a/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
@@ -1,7 +1,9 @@
 package com.mapzen.jpostal;
 
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TestAddressExpander {
     private static boolean expansionInOutput(String[] expansions, String output) {
@@ -26,6 +28,27 @@ public class TestAddressExpander {
         String[] expansions = expander.expandAddressWithOptions(address, options);
 
         return expansionInOutput(expansions, output);
+    }
+
+    @Test
+    public void testExpandNull() {
+        AddressExpander expander = AddressExpander.getInstance();
+        ExpanderOptions options = new ExpanderOptions.Builder().build();
+
+        try {
+            expander.expandAddress(null);
+            fail("Should throw NullPointerException to protect JNI");
+        } catch (NullPointerException e) {}
+
+        try {
+            expander.expandAddressWithOptions(null, options);
+            fail("Should throw NullPointerException to protect JNI");
+        } catch (NullPointerException e) {}
+
+        try {
+            expander.expandAddressWithOptions("address", null);
+            fail("Should throw NullPointerException to protect JNI");
+        } catch (NullPointerException e) {}
     }
 
     @Test

--- a/src/test/java/com/mapzen/jpostal/TestAddressParser.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressParser.java
@@ -1,8 +1,10 @@
 package com.mapzen.jpostal;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import static org.junit.Assert.fail;
 
 public class TestAddressParser {
     private static void testParse(String address, ParsedComponent... expectedOutput) {
@@ -18,7 +20,28 @@ public class TestAddressParser {
             assertEquals(c1.getLabel(), c2.getLabel());
             assertEquals(c1.getValue(), c2.getValue());
         }
-    } 
+    }
+
+    @Test
+    public void testParseNull() {
+        AddressParser parser = AddressParser.getInstance();
+        ParserOptions options = new ParserOptions.Builder().build();
+
+        try {
+            parser.parseAddress(null);
+            fail("Should throw NullPointerException to protect JNI");
+        } catch (NullPointerException e) {}
+
+        try {
+            parser.parseAddressWithOptions(null, options);
+            fail("Should throw NullPointerException to protect JNI");
+        } catch (NullPointerException e) {}
+
+        try {
+            parser.parseAddressWithOptions("address", null);
+            fail("Should throw NullPointerException to protect JNI");
+        } catch (NullPointerException e) {}
+    }
 
     @Test
     public void testParseUSAddress() {


### PR DESCRIPTION
jni_GetStringUTFChars segfaults when given a null jstring.

Ideally, the JVM should not crash but JNI introduces the risk. This protects against a few obvious cases.

It's the most correct way of implementing nullchecks for JNI based on my research.