### PR TITLE
Add defensive checks for NUL bytes in input strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,21 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+.gradle/
+Makefile
+build/
+src/main/c
+m4/
+Makefile.in
+m4/
+src/main/jniLibs/
+config*
+aclocal.m4
+autom4te.cache/
+compile
+depcomp
+install-sh
+libtool
+ltmain.sh
+missing
+stamp-h1

--- a/src/main/java/com/mapzen/jpostal/AddressExpander.java
+++ b/src/main/java/com/mapzen/jpostal/AddressExpander.java
@@ -1,7 +1,5 @@
 package com.mapzen.jpostal;
 
-import com.mapzen.jpostal.ExpanderOptions;
-
 public class AddressExpander {
     static {
         System.loadLibrary("jpostal_expander"); // Load native library at runtime
@@ -41,6 +39,8 @@ public class AddressExpander {
         if (options == null) {
             throw new NullPointerException("ExpanderOptions options must not be null");
         }
+        if (address.contains("\0"))
+            throw new IllegalArgumentException("Input cannot contain null bytes");
 
         synchronized(this) {
             return libpostalExpand(address, options);

--- a/src/main/java/com/mapzen/jpostal/AddressParser.java
+++ b/src/main/java/com/mapzen/jpostal/AddressParser.java
@@ -1,8 +1,5 @@
 package com.mapzen.jpostal;
 
-import com.mapzen.jpostal.ParsedComponent;
-import com.mapzen.jpostal.ParserOptions;
-
 public class AddressParser {
     static {
         System.loadLibrary("jpostal_parser"); // Load native library at runtime
@@ -41,6 +38,8 @@ public class AddressParser {
         if (options == null) {
             throw new NullPointerException("ParserOptions options must not be null");
         }
+        if (address.contains("\0"))
+            throw new IllegalArgumentException("Input cannot contain null bytes");
 
         synchronized(this) {
             return libpostalParse(address, options);

--- a/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
@@ -51,6 +51,18 @@ public class TestAddressExpander {
         } catch (NullPointerException e) {}
     }
 
+    @Test(timeout=1000)
+    public void testNullChars() {
+        AddressExpander parser = AddressExpander.getInstance();
+        try {
+            parser.expandAddress("hello\0world");
+            fail("Should throw IllegalArgumentException to protect JNI");
+        }
+        catch (IllegalArgumentException e) {
+
+        }
+    }
+
     @Test
     public void testEnglishExpansions() {
         assertTrue(containsExpansion("123 Main St", "123 main street"));

--- a/src/test/java/com/mapzen/jpostal/TestAddressParser.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressParser.java
@@ -43,6 +43,18 @@ public class TestAddressParser {
         } catch (NullPointerException e) {}
     }
 
+    @Test(timeout=1000)
+    public void testNullChars() {
+        AddressParser parser = AddressParser.getInstance();
+        try {
+            parser.parseAddress("hello\0world");
+            fail("Should throw IllegalArgumentException to protect JNI");
+        }
+        catch (IllegalArgumentException e) {
+
+        }
+    }
+
     @Test
     public void testParseUSAddress() {
         testParse("781 Franklin Ave Crown Heights Brooklyn NYC NY 11216 USA", 


### PR DESCRIPTION
If an input string contains a NUL byte, then the JNI string->char* conversion will get confused, and libpostal hangs in the native method call.  This PR adds defensive checks to AddressParser and AddressExpander to prevent this.