### PR TITLE
Fix modified utf-8 issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.https.protocols=TLSv1.2

--- a/src/main/java/com/mapzen/jpostal/AddressExpander.java
+++ b/src/main/java/com/mapzen/jpostal/AddressExpander.java
@@ -2,6 +2,8 @@ package com.mapzen.jpostal;
 
 import com.mapzen.jpostal.ExpanderOptions;
 
+import java.nio.charset.StandardCharsets;
+
 public class AddressExpander {
     static {
         System.loadLibrary("jpostal_expander"); // Load native library at runtime
@@ -27,7 +29,7 @@ public class AddressExpander {
 
     static native synchronized void setup();
     static native synchronized void setupDataDir(String dataDir);
-    private static native synchronized String[] libpostalExpand(String address, ExpanderOptions options);
+    private static native synchronized byte[][] libpostalExpand(byte[] address, ExpanderOptions options);
     static native synchronized void teardown();
 
     public String[] expandAddress(String address) {
@@ -43,7 +45,12 @@ public class AddressExpander {
         }
 
         synchronized(this) {
-            return libpostalExpand(address, options);
+            byte[][] expansionBytes = libpostalExpand(address.getBytes(), options);
+            String expansions[] = new String[expansionBytes.length];
+            for (int i = 0; i < expansionBytes.length; i++) {
+                expansions[i] = new String(expansionBytes[i], StandardCharsets.UTF_8);
+            }
+            return expansions;
         }
     }
 

--- a/src/main/java/com/mapzen/jpostal/AddressParser.java
+++ b/src/main/java/com/mapzen/jpostal/AddressParser.java
@@ -10,7 +10,7 @@ public class AddressParser {
 
     static native synchronized void setup();
     static native synchronized void setupDataDir(String dataDir);
-    private native synchronized ParsedComponent[] libpostalParse(String address, ParserOptions options);
+    private native synchronized ParsedComponent[] libpostalParse(byte[] address, ParserOptions options);
     static native synchronized void teardown();
 
     private volatile static AddressParser instance = null;
@@ -43,7 +43,7 @@ public class AddressParser {
         }
 
         synchronized(this) {
-            return libpostalParse(address, options);
+            return libpostalParse(address.getBytes(), options);
         }
     } 
 

--- a/src/main/java/com/mapzen/jpostal/ParsedComponent.java
+++ b/src/main/java/com/mapzen/jpostal/ParsedComponent.java
@@ -1,5 +1,7 @@
 package com.mapzen.jpostal;
 
+import java.nio.charset.StandardCharsets;
+
 public class ParsedComponent {
     private String value;
     private String label;
@@ -22,6 +24,11 @@ public class ParsedComponent {
 
     public ParsedComponent(String value, String label) {
         this.value = value;
+        this.label = label;
+    }
+
+    public ParsedComponent(byte[] value, String label) {
+        this.value = new String(value, StandardCharsets.UTF_8);
         this.label = label;
     }
 }

--- a/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
@@ -60,5 +60,18 @@ public class TestAddressExpander {
         assertTrue(containsExpansionWithOptions("30 West Twenty-sixth St Fl No. 7", "30 west 26th street floor number 7", englishOptions));
     }
 
+    @Test
+    public void testNulTerminatedExpansion() {
+        assertTrue(containsExpansion("123 Main St\u0000", "123 main street"));
+    }
 
+    @Test
+    public void testAltNulTerminatedExpansion() {
+        assertTrue(containsExpansion("123 Main St\0", "123 main street"));
+    }
+
+    @Test
+    public void test4ByteCharacterExpansion() {
+        assertTrue(containsExpansion("123 Main St, 𠜎𠜱𠝹𠱓, 😀🤠", "123 main street 𠜎𠜱𠝹𠱓 😀🤠"));
+    }
 }

--- a/src/test/java/com/mapzen/jpostal/TestAddressParser.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressParser.java
@@ -56,4 +56,31 @@ public class TestAddressParser {
                   new ParsedComponent("usa", "country")
                  );
     }
+
+    @Test
+    public void testParseNulTerminatedAddress() {
+        testParse("Rue du Médecin-Colonel Calbairac Toulouse France\u0000", 
+                  new ParsedComponent("rue du médecin-colonel calbairac", "road"),
+                  new ParsedComponent("toulouse", "city"),
+                  new ParsedComponent("france", "country")
+                 );
+    }
+
+    @Test
+    public void testParseAltNulTerminatedAddress() {
+        testParse("Rue du Médecin-Colonel Calbairac Toulouse France\0", 
+                  new ParsedComponent("rue du médecin-colonel calbairac", "road"),
+                  new ParsedComponent("toulouse", "city"),
+                  new ParsedComponent("france", "country")
+                 );
+    }
+
+    @Test
+    public void testParse4ByteCharacterAddress() {
+        testParse("𠜎𠜱𠝹𠱓, 😀🤠, London, UK", 
+                  new ParsedComponent("𠜎𠜱𠝹𠱓 😀🤠", "house"),
+                  new ParsedComponent("london", "city"),
+                  new ParsedComponent("uk", "country")
+                 );
+    }
 }


### PR DESCRIPTION
I recently bumped into JNI's usage of modified UTF-8, which was causing the parser / expander to error and hang when I passed in any address which contained \0, \u0000 or any 4 byte UTF-8 character.

I did a bit of reading up on the way to work around the issue (this blog was quite instructive: http://banachowski.com/deprogramming/2012/02/working-around-jni-utf-8-strings/), and had a crack at making a fix to avoid the usage of `NewStringUTF` and `GetStringUTFChars` and instead passing `jbyteArray` into and out of the JNI code.

I've added some new tests which were failing before the change, and are now passing for me. This was the first time going anywhere near C code for me so would be really appreciative if someone could check I'm not doing anything really stupid or dangerous e.g. not releasing memory (I can see this project has been dormant for a while so will understand if that's not possible!).

This should fix 
https://github.com/openvenues/jpostal/issues/36

And also hopefully is the more general solution you referenced in this other pull request:
https://github.com/openvenues/jpostal/pull/22

Noteworthy things:
1. If you pass in a \0 or \u0000 character in the middle of your address string the rest of the string will be truncated (I assume this is because C uses NUL terminated char arrays so it just stops at a NUL char). Removing these from the middle of an address felt like something that should be done as an upfront step by the user rather than in jpostal

2. There are still usages of `GetStringUTFChars` and `NewStringUTF`  remaining, but they are for strings which should shouldn't contain problematic characters, e.g. languages and other parser options. I've only changed how the address input string is handled