### PR TITLE
Expose option to explicitly specify JPostal library path

### DIFF
--- a/src/jpostal/c/jpostal_AddressExpander.c
+++ b/src/jpostal/c/jpostal_AddressExpander.c
@@ -6,22 +6,22 @@
 JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressExpander_setup
   (JNIEnv *env, jclass cls) {
 
-    if (!libpostal_setup() || !libpostal_setup_language_classifier()) {
+    if (!libpostal_setup_language_classifier()) {
         jclass exceptionClass;
         exceptionClass = (*env)->FindClass(env, "java/lang/RuntimeException");
         if (exceptionClass == NULL) return;
-        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal expansion modules\n");
+        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal expansion modules");
     }
 }
 
 JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressExpander_setupDataDir
   (JNIEnv *env, jclass cls, jstring jDataDir) {
     const char *datadir = (*env)->GetStringUTFChars(env, jDataDir, 0);
-    if (!libpostal_setup_datadir((char *)datadir) || !libpostal_setup_language_classifier_datadir((char *)datadir)) {
+    if (!libpostal_setup_language_classifier_datadir((char *)datadir)) {
         jclass exceptionClass;
         exceptionClass = (*env)->FindClass(env, "java/lang/IllegalArgumentException");
         if (exceptionClass == NULL) return;
-        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal expansion modules\n");
+        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal expansion modules with data dir");
     }
 }
 
@@ -240,7 +240,6 @@ JNIEXPORT jobjectArray JNICALL Java_com_mapzen_jpostal_AddressExpander_libpostal
 
 JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressExpander_teardown
   (JNIEnv *env, jclass cls) {
-    libpostal_teardown();
     libpostal_teardown_language_classifier();
 }
 

--- a/src/jpostal/c/jpostal_AddressParser.c
+++ b/src/jpostal/c/jpostal_AddressParser.c
@@ -4,22 +4,22 @@
 JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressParser_setup
   (JNIEnv *env, jclass cls) {
 
-    if (!libpostal_setup() || !libpostal_setup_parser()) {
+    if (!libpostal_setup_parser()) {
         jclass exceptionClass;
         exceptionClass = (*env)->FindClass(env, "java/lang/RuntimeException");
         if (exceptionClass == NULL) return;
-        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal parser modules\n");
+        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal parser modules");
     }
 }
 
 JNIEXPORT void JNICALL Java_com_mapzen_jpostal_AddressParser_setupDataDir
   (JNIEnv *env, jclass cls, jstring jDataDir) {
     const char *datadir = (*env)->GetStringUTFChars(env, jDataDir, 0);
-    if (!libpostal_setup_datadir((char *)datadir) || !libpostal_setup_parser_datadir((char *)datadir)) {
+    if (!libpostal_setup_parser_datadir((char *)datadir)) {
         jclass exceptionClass;
         exceptionClass = (*env)->FindClass(env, "java/lang/IllegalArgumentException");
         if (exceptionClass == NULL) return;
-        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal parser modules\n");
+        (*env)->ThrowNew(env, exceptionClass, "Error loading libpostal parser modules with data dir");
     }    
 }
 
@@ -129,4 +129,3 @@ JNIEXPORT void JNICALL Java_com_mapzen_jpostal_ParserOptions_00024Builder_setDef
     (*env)->SetObjectField(env, builder, fid, NULL);
 
 }
-

--- a/src/jpostal/c/jpostal_LibPostal.c
+++ b/src/jpostal/c/jpostal_LibPostal.c
@@ -1,0 +1,29 @@
+#include <jni.h>
+#include <libpostal/libpostal.h>
+
+JNIEXPORT void JNICALL Java_com_mapzen_jpostal_LibPostal_setup
+  (JNIEnv *env, jclass cls) {
+
+    if (!libpostal_setup()) {
+        jclass exceptionClass;
+        exceptionClass = (*env)->FindClass(env, "java/lang/RuntimeException");
+        if (exceptionClass == NULL) return;
+        (*env)->ThrowNew(env, exceptionClass, "Error initializing libpostal");
+    }
+}
+
+JNIEXPORT void JNICALL Java_com_mapzen_jpostal_LibPostal_setupDataDir
+  (JNIEnv *env, jclass cls, jstring jDataDir) {
+    const char *datadir = (*env)->GetStringUTFChars(env, jDataDir, 0);
+    if (!libpostal_setup_datadir((char *)datadir)) {
+        jclass exceptionClass;
+        exceptionClass = (*env)->FindClass(env, "java/lang/RuntimeException");
+        if (exceptionClass == NULL) return;
+        (*env)->ThrowNew(env, exceptionClass, "Error initializing libpostal with datadir");
+    }
+}
+
+JNIEXPORT void JNICALL Java_com_mapzen_jpostal_LibPostal_teardown
+  (JNIEnv *env, jclass cls) {
+    libpostal_teardown();
+}

--- a/src/main/java/com/mapzen/jpostal/AddressParser.java
+++ b/src/main/java/com/mapzen/jpostal/AddressParser.java
@@ -4,10 +4,6 @@ import com.mapzen.jpostal.ParsedComponent;
 import com.mapzen.jpostal.ParserOptions;
 
 public class AddressParser {
-    static {
-        System.loadLibrary("jpostal"); // Load native library at runtime
-    }
-
     static native synchronized void setup();
     static native synchronized void setupDataDir(String dataDir);
     private native synchronized ParsedComponent[] libpostalParse(String address, ParserOptions options);
@@ -15,13 +11,21 @@ public class AddressParser {
 
     private volatile static AddressParser instance = null;
 
+    private final Config config;
+
     public static AddressParser getInstanceDataDir(String dataDir) {
+        return getInstanceConfig(Config.builder().dataDir(dataDir).build());
+    }
+
+    public static AddressParser getInstanceConfig(Config config) {
         if (instance == null) {
             synchronized(AddressParser.class) {
                 if (instance == null) {
-                    instance = new AddressParser(dataDir);
+                    instance = new AddressParser(config);
                 }
             }
+        } else if (!instance.config.equals(config)) {
+            throw Config.mismatchException(instance.config, config);
         }
         return instance;
     }
@@ -47,16 +51,22 @@ public class AddressParser {
         }
     } 
 
-    protected AddressParser(String dataDir) {
+    protected AddressParser(Config config) {
+        config.loadLibrary();
+        new ParserOptions.Builder().setDefaultOptions();
+
+        final String dataDir = config.getDataDir();
         if (dataDir == null) {
             setup();
         } else {
             setupDataDir(dataDir);
         }
+
+        this.config = config;
     }
 
+    @Override
     protected void finalize() {
         teardown();
     }
-
 }

--- a/src/main/java/com/mapzen/jpostal/Config.java
+++ b/src/main/java/com/mapzen/jpostal/Config.java
@@ -1,0 +1,75 @@
+package com.mapzen.jpostal;
+
+import java.util.Objects;
+
+public final class Config {
+    private final String dataDir;
+    private final String libraryFile;
+
+    private Config(final String dataDir, final String libraryFile) {
+        this.dataDir = dataDir;
+        this.libraryFile = libraryFile;
+    }
+
+    public String getDataDir() {
+        return dataDir;
+    }
+
+    public String getLibraryFile() {
+        return libraryFile;
+    }
+
+    void loadLibrary() {
+        if (this.libraryFile != null) {
+            System.load(this.libraryFile);
+        } else {
+            System.loadLibrary("jpostal");
+        }
+    }
+
+    static IllegalArgumentException mismatchException(final Config current, final Config requested) {
+        return new IllegalArgumentException(String.format("Config mismatch: initialized instance uses [%s], but requested [%s]", current, requested));
+    }
+
+    @Override
+    public String toString() {
+        return "Config{" + "dataDir=" + dataDir + ",libraryFile=" + libraryFile + '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        } else if (!(o instanceof Config other)) {
+            return false;
+        } else {
+            return Objects.equals(this.dataDir, other.dataDir) &&
+                    Objects.equals(this.libraryFile, other.libraryFile);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String dataDir;
+        private String libraryFile;
+
+        private Builder() {}
+
+        public Config build() {
+            return new Config(dataDir, libraryFile);
+        }
+
+        public Builder dataDir(final String dataDir) {
+            this.dataDir = dataDir;
+            return this;
+        }
+
+        public Builder libraryFile(final String libraryFile) {
+            this.libraryFile = libraryFile;
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/mapzen/jpostal/ExpanderOptions.java
+++ b/src/main/java/com/mapzen/jpostal/ExpanderOptions.java
@@ -197,7 +197,17 @@ public class ExpanderOptions {
         private boolean expandNumex;
         private boolean romanNumerals;
 
-        native synchronized void setDefaultOptions();
+        private native void setDefaultOptions();
+
+        public Builder() {
+            if (!AddressExpander.isInitialized()) {
+                throw new IllegalStateException("Initialize AddressExpander through getInstance* before creating an ExpanderOptions builder");
+            }
+
+            synchronized (ExpanderOptions.class) {
+                setDefaultOptions(); // Load default options from libpostal into this Builder.
+            }
+        }
 
         public Builder languages(String[] languages) { 
             this.languages = languages;
@@ -308,14 +318,14 @@ public class ExpanderOptions {
     private ExpanderOptions(Builder builder) {
         languages = builder.languages;
         addressComponents = builder.addressComponents;
-        latinAscii = builder.latinAscii;
+        latinAscii = builder.latinAscii; // FIXME: Duplicated
         transliterate = builder.transliterate;
         stripAccents = builder.stripAccents;
         decompose = builder.decompose;
         lowercase = builder.lowercase;
         trimString = builder.trimString;
         dropParentheticals = builder.dropParentheticals;
-        latinAscii = builder.latinAscii;
+        latinAscii = builder.latinAscii; // FIXME: Duplicated
         replaceNumericHyphens = builder.replaceNumericHyphens;
         deleteNumericHyphens = builder.deleteNumericHyphens;
         splitAlphaFromNumeric = builder.splitAlphaFromNumeric;

--- a/src/main/java/com/mapzen/jpostal/ExpanderOptions.java
+++ b/src/main/java/com/mapzen/jpostal/ExpanderOptions.java
@@ -176,10 +176,6 @@ public class ExpanderOptions {
     }
 
     public static class Builder {
-        static {
-            System.loadLibrary("jpostal"); // Load native library at runtime
-        }
-
         private String[] languages;
         private short addressComponents;
         private boolean latinAscii;
@@ -201,12 +197,7 @@ public class ExpanderOptions {
         private boolean expandNumex;
         private boolean romanNumerals;
 
-        private native synchronized void setDefaultOptions();
-
-        public Builder() {
-            super();
-            setDefaultOptions();
-        }
+        native synchronized void setDefaultOptions();
 
         public Builder languages(String[] languages) { 
             this.languages = languages;

--- a/src/main/java/com/mapzen/jpostal/LibPostal.java
+++ b/src/main/java/com/mapzen/jpostal/LibPostal.java
@@ -1,0 +1,50 @@
+package com.mapzen.jpostal;
+
+final class LibPostal {
+    private final Config config;
+
+    private LibPostal(final Config config) {
+        if (config == null) {
+            throw new NullPointerException("Config must not be null");
+        }
+
+        config.loadLibrary();
+
+        final String dataDir = config.getDataDir();
+        if (dataDir == null) {
+            setup();
+        } else {
+            setupDataDir(dataDir);
+        }
+
+        this.config = config;
+    }
+
+    Config getConfig() {
+        return config;
+    }
+
+    private static native void setup();
+    private static native void setupDataDir(final String dataDir);
+    private static native void teardown();
+
+    private volatile static LibPostal instance = null;
+
+    static LibPostal getInstance(final Config config) {
+       if (instance == null) {
+            synchronized(LibPostal.class) {
+                if (instance == null ) {
+                    instance = new LibPostal(config);
+                }
+            }
+        } else if (!instance.config.equals(config)) {
+           throw Config.mismatchException(instance.config, config);
+       }
+       return instance;
+    }
+
+    @Override
+    protected void finalize() {
+        teardown();
+    }
+}

--- a/src/main/java/com/mapzen/jpostal/ParserOptions.java
+++ b/src/main/java/com/mapzen/jpostal/ParserOptions.java
@@ -5,19 +5,10 @@ public class ParserOptions {
     private String country;
 
     public static class Builder {
-        static {
-            System.loadLibrary("jpostal"); // Load native library at runtime
-        }
-
         private String language;
         private String country;
 
-        private native synchronized void setDefaultOptions();
-
-        public Builder() {
-            super();
-            setDefaultOptions();
-        }
+        native synchronized void setDefaultOptions();
 
         public Builder language(String language) {
             this.language = language;
@@ -38,5 +29,4 @@ public class ParserOptions {
         this.language = builder.language;
         this.country = builder.country;
     }
-
 }

--- a/src/main/java/com/mapzen/jpostal/ParserOptions.java
+++ b/src/main/java/com/mapzen/jpostal/ParserOptions.java
@@ -1,14 +1,24 @@
 package com.mapzen.jpostal;
 
 public class ParserOptions {
-    private String language;
-    private String country;
+    private final String language;
+    private final String country;
 
     public static class Builder {
         private String language;
         private String country;
 
-        native synchronized void setDefaultOptions();
+        private native void setDefaultOptions();
+
+        public Builder() {
+            if (!AddressParser.isInitialized()) {
+                throw new IllegalStateException("Initialize AddressParser through getInstance* before creating a ParserOptions Builder");
+            }
+
+            synchronized (ParserOptions.class) {
+                setDefaultOptions(); // Load default options from libpostal into this Builder.
+            }
+        }
 
         public Builder language(String language) {
             this.language = language;

--- a/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
@@ -19,6 +19,9 @@ public class TestAddressExpander {
         AddressExpander expander = AddressExpander.getInstance();
         String[] expansions = expander.expandAddress(address);
 
+        System.err.println(String.format("address=%s   expected=%s   expansions=%s", address, output, java.util.Arrays.toString(expansions)));
+
+
         return expansionInOutput(expansions, output);
     }
 
@@ -66,6 +69,8 @@ public class TestAddressExpander {
         IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
             AddressExpander.getInstanceDataDir("foo");
         });
+
+        System.err.println("THROWN = " + thrown);
 
         assertEquals(
                 "Config mismatch: initialized instance uses [Config{dataDir=null,libraryFile=null}], but requested [Config{dataDir=foo,libraryFile=null}]",

--- a/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressExpander.java
@@ -2,8 +2,7 @@ package com.mapzen.jpostal;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class TestAddressExpander {
     private static boolean expansionInOutput(String[] expansions, String output) {
@@ -60,5 +59,33 @@ public class TestAddressExpander {
         assertTrue(containsExpansionWithOptions("30 West Twenty-sixth St Fl No. 7", "30 west 26th street floor number 7", englishOptions));
     }
 
+    @Test()
+    public void testConfigMismatchDataDir() {
+        AddressExpander.getInstance();
 
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+            AddressExpander.getInstanceDataDir("foo");
+        });
+
+        assertEquals(
+                "Config mismatch: initialized instance uses [Config{dataDir=null,libraryFile=null}], but requested [Config{dataDir=foo,libraryFile=null}]",
+                thrown.getMessage()
+        );
+        assertNull(thrown.getCause());
+    }
+
+    @Test()
+    public void testConfigMismatchLibraryFile() {
+        AddressExpander.getInstance();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+            AddressExpander.getInstanceConfig(Config.builder().libraryFile("foo").build());
+        });
+
+        assertEquals(
+                "Config mismatch: initialized instance uses [Config{dataDir=null,libraryFile=null}], but requested [Config{dataDir=null,libraryFile=foo}]",
+                thrown.getMessage()
+        );
+        assertNull(thrown.getCause());
+    }
 }

--- a/src/test/java/com/mapzen/jpostal/TestAddressParser.java
+++ b/src/test/java/com/mapzen/jpostal/TestAddressParser.java
@@ -2,16 +2,15 @@ package com.mapzen.jpostal;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 
 public class TestAddressParser {
     private static void testParse(String address, ParsedComponent... expectedOutput) {
         AddressParser parser = AddressParser.getInstance();
         ParsedComponent[] parsedComponents = parser.parseAddress(address);
 
-        assertTrue(parsedComponents.length == expectedOutput.length);
+        assertEquals(expectedOutput.length, parsedComponents.length);
 
         for (int i = 0; i < parsedComponents.length; i++) {
             ParsedComponent c1 = parsedComponents[i];
@@ -55,5 +54,36 @@ public class TestAddressParser {
                   new ParsedComponent("11216", "postcode"),
                   new ParsedComponent("usa", "country")
                  );
+    }
+
+
+    @Test()
+    public void testConfigMismatchDataDir() {
+        AddressParser.getInstance();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+            AddressParser.getInstanceDataDir("foo");
+        });
+
+        assertEquals(
+                "Config mismatch: initialized instance uses [Config{dataDir=null,libraryFile=null}], but requested [Config{dataDir=foo,libraryFile=null}]",
+                thrown.getMessage()
+        );
+        assertNull(thrown.getCause());
+    }
+
+    @Test()
+    public void testConfigMismatchLibraryFile() {
+        AddressParser.getInstance();
+
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () -> {
+            AddressParser.getInstanceConfig(Config.builder().libraryFile("foo").build());
+        });
+
+        assertEquals(
+                "Config mismatch: initialized instance uses [Config{dataDir=null,libraryFile=null}], but requested [Config{dataDir=null,libraryFile=foo}]",
+                thrown.getMessage()
+        );
+        assertNull(thrown.getCause());
     }
 }

--- a/src/test/java/com/mapzen/jpostal/TestConfig.java
+++ b/src/test/java/com/mapzen/jpostal/TestConfig.java
@@ -1,0 +1,58 @@
+package com.mapzen.jpostal;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestConfig {
+    @Test
+    public void testBuilderDefault() {
+        Config config = Config.builder().build();
+
+        assertEquals(config, config);
+        assertEquals("Config{dataDir=null,libraryFile=null}", config.toString());
+        assertNull(config.getDataDir());
+        assertNull(config.getLibraryFile());
+    }
+
+    @Test
+    public void testBuilderDataDir() {
+        Config dataDirConfig = Config.builder().dataDir("foo").build();
+        Config defaultConfig = Config.builder().build();
+
+        assertEquals(dataDirConfig, dataDirConfig);
+        assertNotEquals(dataDirConfig, defaultConfig);
+        assertNotEquals(defaultConfig, dataDirConfig);
+        assertEquals("Config{dataDir=foo,libraryFile=null}", dataDirConfig.toString());
+        assertEquals("foo", dataDirConfig.getDataDir());
+        assertNull(dataDirConfig.getLibraryFile());
+    }
+
+    @Test
+    public void testBuilderLibraryFile() {
+        Config libraryFileConfig = Config.builder().libraryFile("foo/libbar.so.1.1").build();
+        Config defaultConfig = Config.builder().build();
+
+        assertEquals(libraryFileConfig, libraryFileConfig);
+        assertNotEquals(libraryFileConfig, defaultConfig);
+        assertNotEquals(defaultConfig, libraryFileConfig);
+        assertEquals("Config{dataDir=null,libraryFile=foo/libbar.so.1.1}", libraryFileConfig.toString());
+        assertEquals("foo/libbar.so.1.1", libraryFileConfig.getLibraryFile());
+        assertNull(libraryFileConfig.getDataDir());
+    }
+
+    @Test
+    public void testBuilderAll() {
+        Config allConfig = Config.builder()
+                .dataDir("hello")
+                .libraryFile("libworld.so").build();
+        Config defaultConfig = Config.builder().build();
+
+        assertEquals(allConfig, allConfig);
+        assertNotEquals(allConfig, defaultConfig);
+        assertNotEquals(defaultConfig, allConfig);
+        assertEquals("Config{dataDir=hello,libraryFile=libworld.so}", allConfig.toString());
+        assertEquals("hello", allConfig.getDataDir());
+        assertEquals("libworld.so", allConfig.getLibraryFile());
+    }
+}


### PR DESCRIPTION
# Description

The purpose of this change is to enable using JPostal within [AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html).

This unblocks "Big Data" use cases of parsing/expanding addresses within a distributed Spark environment on the AWS-managed Glue platform.

Within AWS Glue's managed Spark environment, it is pretty much impossible to override `LD_LIBRARY_PATH` in a way that makes JPostal's `System.load("jpostal")` call able to find the JPostal shared object.

## Change details

This change refactors the code base to add an option to explicitly specify the library location so the JPostal shared object can be provided to Glue driver and executor nodes via Glue's existing extra files/additional files/referenced files feature, and Glue users can load the library from the place the Glue framework stores it, which is currently `/tmp/`, at least on the latest version, Glue 5.

### Example use of new feature

```java
AddressExpander expander = AddressExpander.getInstanceConfig(Config.builder()
    .dataDir("/path/to/data")
    .libraryName("/exact/path/to/jpostal.so")
    .build()
);
...
```

The same construct is also available for `AddressParser`.

## Backward-compatibility

This change is fully backwardly-compatible. JPostal users can continue doing this:

```java
AddressExpander expander = AddressExpander.getInstance();
...
```

And this:

```java
AddressExpander expander = AddressExpander.getInstanceDataDir("/path/to/data");
...
```

As well as using the equivalent constructs for `AddressParser`.

## Incidental Changes

As part of this change, the thread-safety of global `libpostal` state is improved in the following ways.

- Global `libpostal` library initialization is done only once, by a `LibPostal` singleton class that is always initialized before  `AddressExpander` or `AddressParser`.
- All attempts to run a duplicate initialization of the main library with different configuration, *e.g.* different native library path, different data directory path, *etc.* should now be impossible because they have to run through the `LibPostal` singleton.

# Testing Done

1. ✅ DONE. Added new unit tests.
2. ✅ DONE. Tested using JPostal in a Scala-based AWS Glue 5 job.

# Example

Example usage of these new features within a working AWS Glue 5 Scala script:

```scala
import com.amazonaws.services.glue.GlueContext
import com.amazonaws.services.glue.log.GlueLogger
import com.mapzen.jpostal.{AddressExpander, AddressParser, Config};
import java.io._
import java.nio.file.{Files, Paths}
import java.util.zip.{ZipEntry, ZipInputStream}
import org.apache.spark.SparkContext
import org.apache.spark.sql.{Row, SparkSession}
import org.apache.spark.sql.api.java.UDF1
import org.apache.spark.sql.functions.udf;
import org.apache.spark.sql.types.{ArrayType, MapType, StringType, StructField}

object LibPostal {
    private val logger = new GlueLogger;
    private lazy val (expander, parser) = {
        loadSharedObjects("/tmp", Seq("libpostal.so.1.0.1", "libjpostal.so"))
        unpackData("/tmp", "data.zip", "/tmp/data")
        initJPostal("/tmp/data", "/tmp/libjpostal.so")
    }

    private def loadSharedObjects(dirPath: String, libraryNames: Seq[String]) {
        logger.info(String.format("Loading shared objects [%s] from directory [%s]..", libraryNames.mkString(", "), dirPath));
        libraryNames.foreach { libraryName => 
            val libraryPath = s"$dirPath/$libraryName";
            logger.info(String.format("Loading shared object [%s]..", libraryPath));
            System.load(libraryPath);
            logger.info(String.format("Loaded shared object [%s].", libraryPath));
        }
        logger.info(String.format("Loaded shared objects [%s] from directory [%s].", libraryNames.mkString(", "), dirPath));
    }

    private def unpackData(srcDir: String, srcZipFileName: String, dstDir: String) {
        logger.info(s"Unpacking ZIP archive [$srcZipFileName] from directory [$srcDir] to directory [$dstDir]...")
        
        val dstDirPath = Paths.get(dstDir)

        logger.info(s"Creating directory [$dstDirPath]...")
        Files.createDirectories(dstDirPath)

        val buf = new Array[Byte](8192)
        val zipFilePath = Paths.get(s"$srcDir/$srcZipFileName")
        logger.info(s"Opening ZIP archive [$zipFilePath]...")
        val zipIn = new ZipInputStream(new FileInputStream(zipFilePath.toFile))
        var numFiles: Long = 0
        var sizeCompressed: Long = 0
        var sizeUncompressed: Long = 0

        logger.info("Unpacking...")
        try {
            var entry: ZipEntry = zipIn.getNextEntry
            while (entry != null) {
                val filePath = dstDirPath.resolve(entry.getName)
                if (entry.isDirectory) {
                    Files.createDirectories(filePath)
                } else {
                    logger.info(s"Unpacking [${entry.getSize}] uncompressed bytes to [${filePath}]...")
                    Files.createDirectories(filePath.getParent)
                    val fileOut = new FileOutputStream(filePath.toFile)
                    try {
                        var len = zipIn.read(buf)
                        while (len > 0) {
                            fileOut.write(buf, 0, len)
                            len = zipIn.read(buf)
                        }
                    } finally {
                        fileOut.close()
                    }
                    numFiles += 1
                    sizeCompressed += entry.getCompressedSize
                    sizeUncompressed += entry.getSize
                }
                entry = zipIn.getNextEntry
            }
        } finally {
            zipIn.close()
        }

        logger.info(s"Unpacked [$srcZipFileName] from directory [$srcDir] to directory [$dstDir]. Got [$numFiles] files and [$sizeUncompressed] uncompressed bytes from [$sizeCompressed] compressed bytes.")
    }
    
    private def initJPostal(dataDir: String, libraryFile: String): (AddressExpander, AddressParser) = {
        val config = Config.builder()
           .dataDir(dataDir)
           .libraryFile(libraryFile)
           .build();

        logger.info(s"Initializing address expander with configuration: [$config]...")
        val expander = AddressExpander.getInstanceConfig(config)

        logger.info("Initializing address parser...")
        val parser = AddressParser.getInstanceConfig(config)

        logger.info("Finished initializing libpostal/JPostal")
    
        (expander, parser)
    }
    
    def expandAddress(address: String): Array[String] = {
        expander.expandAddress(address)
    }

    def parseAddress(address: String): Map[String, String] = {
        val parsedComponents = parser.parseAddress(address)
        
        parsedComponents
            .toSeq
            .map(c => c.getLabel -> c.getValue)
            .toMap
    }
}

class ExpandAddress extends UDF1[String, Array[String]] {
    override def call(address: String): Array[String] = {
        LibPostal.expandAddress(address)
    }
}

object ExpandAddress {
    val schema = new ArrayType(StringType, false)
}

class ParseAddress extends UDF1[String, Map[String, String]] {
    override def call(address: String): Map[String, String] = {
        LibPostal.parseAddress(address)
    }
}

object ParseAddress {
    val schema = new MapType(StringType, StringType, valueContainsNull = false)
}

/**
 * Glue expects to find an `object` named `GlueApp` in the compiled script and will
 * fail with a `ClassNotFoundException` if it doesn't find it. You can change this
 * behavior with the `--class` argument, the default value of which, in Glue 5, is
 * `GlueApp`.
 *
 * S3 JARs listed in the "Dependent JARS path" (`--extra-jars` argument) get
 * automatically placed on the JVM classpath.
 *
 * S3-hosted objects listed in the "Referenced files path" (`--extra-files` argument)
 * get automatically downloaded to `/tmp`.
 */
object GlueApp {
  def main(sysArgs: Array[String]): Unit = {
    val sparkContext: SparkContext = new SparkContext()
    val glueContext: GlueContext = new GlueContext(sparkContext)
    val sparkSession: SparkSession = glueContext.getSparkSession
    import sparkSession.implicits._ // Weird Scala thing to import extension methods like .toDF(...)`

    val expandAddressUdf = udf(new ExpandAddress, ExpandAddress.schema)
    val parseAddressUdf = udf(new ParseAddress, ParseAddress.schema)
    
    val df = Seq(
        "Quatre vingt douze Ave des Champs-Élysées",
        "1600 Pennsylvania Avenue NW, Washington, D.C. 20500, U.S."
    ).toDF("input")

    val resultDf = df
        .withColumn("expandedAddress", expandAddressUdf($"input"))
        .withColumn("parsedAddress", parseAddressUdf($"input"))

    resultDf.show(Int.MaxValue, truncate = false);
  }
}
```