### PR TITLE
Update documentation to reflect JDK 16 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ After running ```gradle assemble``` the .so/.jniLib files can be found under ```
 Compatibility
 -------------
 
-Building jpostal is known to work on Linux and Mac OSX (including Mac silicon). 
+-  Building jpostal is known to work on Linux and Mac OSX (including Mac silicon).
+-  Requires JDK 16 or later. Make sure JAVA_HOME points to JDK 16+. 
+
 
 Tests
 -----

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import org.gradle.internal.jvm.Jvm
-import org.gradle.nativeplatform.toolchain.*
 
 plugins {
     id 'c'
@@ -14,22 +13,18 @@ repositories {
 sourceSets.main.java.srcDirs = ["src/main/java"]
 sourceSets.test.java.srcDirs = ["src/test/java"]
 
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
+
 model {
-    toolChains {
-        gcc(Gcc){
-            target("linux_aarch64") {
-                cCompiler.executable = "/usr/bin/gcc"
-                cppCompiler.executable = "/usr/bin/g++"
-            }
-        }
-    }
     platforms {
-        x64 {
-            architecture "x86_64"
-        }
         linux_aarch64 {
             architecture "arm64"
             operatingSystem "linux"
+        }
+        osx_aarch64 {
+            architecture "arm64"
+            operatingSystem "mac os x"
         }
     }
 


### PR DESCRIPTION
Make JDK 16+ requirement explicit in build and README
Also Rollback explicit toolchain declaration because it prevents gradle toolchain auto-detection