### PR TITLE
fix: correct usage of cleaner api

### DIFF
--- a/src/main/java/com/mapzen/jpostal/AddressExpander.java
+++ b/src/main/java/com/mapzen/jpostal/AddressExpander.java
@@ -5,7 +5,6 @@ import java.lang.ref.Cleaner;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AddressExpander {
-    private static final Cleaner cleaner = Cleaner.create();
     private static final AtomicBoolean isShutdown = new AtomicBoolean(false);
     
     private volatile static AddressExpander instance = null;
@@ -79,8 +78,20 @@ public class AddressExpander {
             }
         }
         
-        // Register cleanup
-        this.cleanable = cleaner.register(this, () -> {
+        this.cleanable = Utils.registerForCleanup(this, new CleanupAction(isShutdown, libPostal));
+    }
+    
+    private static class CleanupAction implements Runnable {
+        private final AtomicBoolean isShutdown;
+        private final LibPostal libPostal;
+        
+        CleanupAction(AtomicBoolean isShutdown, LibPostal libPostal) {
+            this.isShutdown = isShutdown;
+            this.libPostal = libPostal;
+        }
+        
+        @Override
+        public void run() {
             if (isShutdown.compareAndSet(false, true)) {
                 try {
                     synchronized (libPostal) {
@@ -90,6 +101,6 @@ public class AddressExpander {
                     System.err.println("AddressExpander cleaner error: " + e.getMessage());
                 }
             }
-        });
+        }
     }
 }

--- a/src/main/java/com/mapzen/jpostal/Utils.java
+++ b/src/main/java/com/mapzen/jpostal/Utils.java
@@ -1,0 +1,16 @@
+package com.mapzen.jpostal;
+
+import java.lang.ref.Cleaner;
+
+final class Utils {
+    
+    private static final Cleaner CLEANER = Cleaner.create();
+    
+    private Utils() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+    
+    static Cleaner.Cleanable registerForCleanup(Object obj, Runnable cleanupAction) {
+        return CLEANER.register(obj, cleanupAction);
+    }
+}


### PR DESCRIPTION
Per several articles online, the correct usage of Cleaner is to:

1. Create a singelton Cleaner thread per library (I put it in Utils.java)
2. Using a lambda will not allow phantom references to be reached (Ie. use a class extending Runnable) https://dev.to/ahmedjaad/java-cleaners-the-modern-way-to-manage-external-resources-4d4#cleaners-behind-the-scene
